### PR TITLE
Fix publishing to NPM in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,16 +132,13 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Cd in to the node bindings
-        run: cd bindings/typescript
-
       - name: Install Dependencies
-        run: npm install
+        run: cd bindings/typescript && npm install
 
       - name: Build
-        run: npm run build
+        run: cd bindings/typescript && npm run build
 
       - name: Publish
-        run: npm publish
+        run: cd bindings/typescript && npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
We can also have a single step, but to me this looks better in the UI.